### PR TITLE
chore: Support customizable dockerfile-path option in deploy

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -5,6 +5,10 @@ on:
         type: string
         required: true
         description: The name of the app, as used for the ECS cluster
+      dockerfile-path:
+        description: Path to the repo's Dockerfile
+        required: false
+        default: '.'
       environment:
         type: string
         required: true
@@ -33,6 +37,7 @@ jobs:
           aws-access-key-id: ${{ secrets.aws-access-key-id }}
           aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
           docker-repo: ${{ secrets.docker-repo }}
+          dockerfile-path: ${{ inputs.dockerfile-path }}
       - uses: mbta/actions/deploy-ecs@v1
         with:
           aws-access-key-id: ${{ secrets.aws-access-key-id }}


### PR DESCRIPTION
This exposes the `dockerfile-path` option in the [underlying build-push action](https://github.com/mbta/actions/blob/main/build-push-ecr/action.yml#L17), which RTR uses.

I believe this change is backwards compatible so all the other apps using the workflow don't need to change anything.