### PR TITLE
Adding new service input to support custom ECS service names

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -18,6 +18,10 @@ on:
         type: string
         required: false
         description: Name of the ECS cluster, defaulting to app-name if not specified
+      service:
+        type: string
+        required: false
+        description: Name of the ECS service, defaulting to app-name-environment if not specified
     secrets:
       aws-access-key-id:
         required: true
@@ -48,7 +52,7 @@ jobs:
           aws-access-key-id: ${{ secrets.aws-access-key-id }}
           aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
           ecs-cluster: ${{ inputs.cluster || inputs.app-name }}
-          ecs-service: ${{ inputs.app-name }}-${{ inputs.environment }}
+          ecs-service: ${{ inputs.service || ( ${{ inputs.app-name }}-${{ inputs.environment }} ) }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
       - uses: mbta/actions/notify-slack-deploy@v1
         if: ${{ !cancelled() }}

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -22,6 +22,10 @@ on:
         type: string
         required: false
         description: Name of the ECS service, defaulting to app-name-environment if not specified
+      task-definition:
+        type: string
+        required: false
+        description: Name of the ECS task, defaulting to app-name-environment if not specified
     secrets:
       aws-access-key-id:
         required: true
@@ -53,6 +57,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
           ecs-cluster: ${{ inputs.cluster || inputs.app-name }}
           ecs-service: ${{ inputs.service || format('{0}-{1}', inputs.app-name, inputs.environment) }}
+          ecs-task-definition: ${{ inputs.task-definition || format('{0}-{1}', inputs.app-name, inputs.environment) }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
       - uses: mbta/actions/notify-slack-deploy@v1
         if: ${{ !cancelled() }}

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -52,7 +52,7 @@ jobs:
           aws-access-key-id: ${{ secrets.aws-access-key-id }}
           aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
           ecs-cluster: ${{ inputs.cluster || inputs.app-name }}
-          ecs-service: ${{ inputs.service || ( ${{ inputs.app-name }}-${{ inputs.environment }} ) }}
+          ecs-service: ${{ inputs.service || ${{ inputs.app-name }}-${{ inputs.environment }} }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
       - uses: mbta/actions/notify-slack-deploy@v1
         if: ${{ !cancelled() }}

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -52,7 +52,7 @@ jobs:
           aws-access-key-id: ${{ secrets.aws-access-key-id }}
           aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
           ecs-cluster: ${{ inputs.cluster || inputs.app-name }}
-          ecs-service: ${{ inputs.service || ${{ inputs.app-name }}-${{ inputs.environment }} }}
+          ecs-service: ${{ inputs.service || format('{0}-{1}', inputs.app-name, inputs.environment) }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
       - uses: mbta/actions/notify-slack-deploy@v1
         if: ${{ !cancelled() }}


### PR DESCRIPTION
Asana ticket: [Make mTicket loader compliant with New Application Checklist](https://app.asana.com/0/1158206118561947/1204311533579527/f)

Adding new `service` input so we can customize ECS service names. It's required for mTicket import. 