### PR TITLE
fix: use correct secret for attachment job

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -59,6 +59,6 @@ jobs:
         uses: Asana/create-app-attachment-github-action@v1.2
         id: postAttachment
         with:
-          asana-secret: ${{ secrets.asana-github-secret }}
+          asana-secret: ${{ secrets.github-secret }}
       - name: Log output status
         run: echo "Status is ${{ steps.postAttachment.outputs.status }}"


### PR DESCRIPTION
Fixes an error I made while renaming the secrets: https://github.com/mbta/rtr/actions/runs/4865599767/jobs/8676113160#step:2:7