### PR TITLE
fix: only run Asana jobs if the secrets are present

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -29,9 +29,17 @@ on:
         required: false
         description: GitHub secret that Asana uses to fetch PR information.
 jobs:
+  check-for-secrets:
+    runs-on: ubuntu-latest
+    outputs:
+      has-asana-token: ${{ secrets.asana-token != '' }}
+      has-github-secret: ${{ secrets.github-secret != '' }}
+    steps:
+      - run: true
   move-to-merged-asana-ticket-job:
     runs-on: ubuntu-latest
-    if: inputs.merged-section != '' && github.event.pull_request.merged == true && github.actor != 'dependabot[bot]' 
+    needs: check-for-secrets
+    if: inputs.merged-section != '' && needs.check-for-secrets.output.has-asana-token == 'true' && github.event.pull_request.merged == true && github.actor != 'dependabot[bot]'
     steps:
       - name: Move ticket on merge
         uses:  mbta/github-asana-action@v4.3.0
@@ -42,7 +50,8 @@ jobs:
           mark-complete: ${{ inputs.complete-on-merge }}
   move-to-in-review-asana-ticket-job:
     runs-on: ubuntu-latest
-    if: inputs.review-section != '' && github.event.action == 'review_requested' && github.actor != 'dependabot[bot]'
+    needs: check-for-secrets
+    if: inputs.review-section != '' && needs.check-for-secrets.output.has-asana-token == 'true' && github.event.action == 'review_requested' && github.actor != 'dependabot[bot]'
     steps:
       - name: Move ticket on review requested
         uses:  mbta/github-asana-action@v4.3.0
@@ -52,8 +61,9 @@ jobs:
           target-section: ${{ inputs.review-section }}
   create-asana-attachment-job:
     runs-on: ubuntu-latest
+    needs: check-for-secrets
     name: Create pull request attachments on Asana tasks
-    if: inputs.attach-pr && github.actor != 'dependabot[bot]'
+    if: inputs.attach-pr && needs.check-for-secrets.output.has-github-secret == 'true' && github.actor != 'dependabot[bot]'
     steps:
       - name: Create pull request attachments
         uses: Asana/create-app-attachment-github-action@v1.2


### PR DESCRIPTION
This avoids failures when running on PRs from forks.

We do it in this convoluted way because you can't access secrets directly from `if` blocks: https://github.com/actions/runner/issues/520

You can see it working in this action run: https://github.com/mbta/api/actions/runs/5469630640/jobs/9958897744