### PR TITLE
Revert "fix: only run Asana jobs if the secrets are present"

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -29,17 +29,9 @@ on:
         required: false
         description: GitHub secret that Asana uses to fetch PR information.
 jobs:
-  check-for-secrets:
-    runs-on: ubuntu-latest
-    outputs:
-      has-asana-token: ${{ secrets.asana-token != '' }}
-      has-github-secret: ${{ secrets.github-secret != '' }}
-    steps:
-      - run: true
   move-to-merged-asana-ticket-job:
     runs-on: ubuntu-latest
-    needs: check-for-secrets
-    if: inputs.merged-section != '' && needs.check-for-secrets.output.has-asana-token == 'true' && github.event.pull_request.merged == true && github.actor != 'dependabot[bot]'
+    if: inputs.merged-section != '' && github.event.pull_request.merged == true && github.actor != 'dependabot[bot]' 
     steps:
       - name: Move ticket on merge
         uses:  mbta/github-asana-action@v4.3.0
@@ -50,8 +42,7 @@ jobs:
           mark-complete: ${{ inputs.complete-on-merge }}
   move-to-in-review-asana-ticket-job:
     runs-on: ubuntu-latest
-    needs: check-for-secrets
-    if: inputs.review-section != '' && needs.check-for-secrets.output.has-asana-token == 'true' && github.event.action == 'review_requested' && github.actor != 'dependabot[bot]'
+    if: inputs.review-section != '' && github.event.action == 'review_requested' && github.actor != 'dependabot[bot]'
     steps:
       - name: Move ticket on review requested
         uses:  mbta/github-asana-action@v4.3.0
@@ -61,9 +52,8 @@ jobs:
           target-section: ${{ inputs.review-section }}
   create-asana-attachment-job:
     runs-on: ubuntu-latest
-    needs: check-for-secrets
     name: Create pull request attachments on Asana tasks
-    if: inputs.attach-pr && needs.check-for-secrets.output.has-github-secret == 'true' && github.actor != 'dependabot[bot]'
+    if: inputs.attach-pr && github.actor != 'dependabot[bot]'
     steps:
       - name: Create pull request attachments
         uses: Asana/create-app-attachment-github-action@v1.2


### PR DESCRIPTION
Reverts mbta/workflows#14

Per @thecristen in https://github.com/mbta/workflows/commit/4f4c6d55c091aa9a5e4b57f282abfd77050a5845, this is breaking the workflows in mbta/dotcom and mbta/rtr.