### PR TITLE
fix: only run Asana jobs if the secrets are present

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -29,9 +29,21 @@ on:
         required: false
         description: GitHub secret that Asana uses to fetch PR information.
 jobs:
+  check-for-secrets:
+    runs-on: ubuntu-latest
+    outputs:
+      has-asana-token: ${{ steps.one.outputs.has-asana-token }}
+      has-github-secret: ${{ steps.one.outputs.has-github-secret }}
+    steps:
+      - id: one
+        run: |
+          [ -n "${{ secrets.asana-token }}" ] && echo "has-asana-token=yes" >> "$GITHUB_OUTPUT"
+          [ -n "${{ secrets.github-secret }}" ] && echo "has-github-secret=yes" >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
   move-to-merged-asana-ticket-job:
     runs-on: ubuntu-latest
-    if: inputs.merged-section != '' && github.event.pull_request.merged == true && github.actor != 'dependabot[bot]' 
+    needs: check-for-secrets
+    if: inputs.merged-section != '' && needs.check-for-secrets.outputs.has-asana-token == 'yes' && github.event.pull_request.merged == true && github.actor != 'dependabot[bot]'
     steps:
       - name: Move ticket on merge
         uses:  mbta/github-asana-action@v4.3.0
@@ -42,7 +54,8 @@ jobs:
           mark-complete: ${{ inputs.complete-on-merge }}
   move-to-in-review-asana-ticket-job:
     runs-on: ubuntu-latest
-    if: inputs.review-section != '' && github.event.action == 'review_requested' && github.actor != 'dependabot[bot]'
+    needs: check-for-secrets
+    if: inputs.review-section != '' && needs.check-for-secrets.outputs.has-asana-token == 'yes' && github.event.action == 'review_requested' && github.actor != 'dependabot[bot]'
     steps:
       - name: Move ticket on review requested
         uses:  mbta/github-asana-action@v4.3.0
@@ -52,8 +65,9 @@ jobs:
           target-section: ${{ inputs.review-section }}
   create-asana-attachment-job:
     runs-on: ubuntu-latest
+    needs: check-for-secrets
     name: Create pull request attachments on Asana tasks
-    if: inputs.attach-pr && github.actor != 'dependabot[bot]'
+    if: inputs.attach-pr && needs.check-for-secrets.outputs.has-github-secret == 'yes' && github.actor != 'dependabot[bot]'
     steps:
       - name: Create pull request attachments
         uses: Asana/create-app-attachment-github-action@v1.2

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # cache the ASDF directory, using the values from .tool-versions
       - name: ASDF cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-v2-${{ hashFiles('.tool-versions') }}
@@ -28,9 +28,9 @@ jobs:
     needs: setup
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: ASDF cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-v2-${{ hashFiles('.tool-versions') }}
@@ -39,3 +39,5 @@ jobs:
         uses: mbta/actions/reshim-asdf@v1
       - name: Shellcheck
         run: shellcheck -a -S style .github/*.sh
+      - name: Check workflow files
+        run: actionlint -color

--- a/.github/workflows/deploy-on-prem.yml
+++ b/.github/workflows/deploy-on-prem.yml
@@ -99,15 +99,15 @@ jobs:
         id: docker
         run: |
           if [ -z "${{ inputs.docker-tag }}" ]; then
-            echo "tag=git-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+            echo "tag=git-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=${{ inputs.docker-tag }}" >> $GITHUB_OUTPUT
+            echo "tag=${{ inputs.docker-tag }}" >> "$GITHUB_OUTPUT"
           fi
       - name: Deploy to ${{ inputs.on-prem-cluster }}
         id: deploy
         run: |
           aws ssm send-command --document-name "${{ inputs.document-name }}" --document-version "\$LATEST" --targets '[{"Key":"resource-groups:Name","Values":["${{ inputs.on-prem-cluster }}"]}]' --parameters '{"ECRRepo":["${{ secrets.docker-repo }}"],"DockerTag":["${{ steps.docker.outputs.tag }}"],"TaskCpu":["${{ inputs.task-cpu }}"], "TaskMemory": ["${{ inputs.task-memory }}"],"TaskPort":["${{ inputs.task-port }}"],"PortMode":["${{ inputs.port-mode }}"],"TaskReplicas":["${{ inputs.task-replicas}}"],"UpdateOrder":["${{ inputs.update-order }}"],"PlacementConstraint":["${{ inputs.placement-constraint }}"],"ServiceName":["${{ inputs.app-name }}-${{ inputs.environment }}"],"EnvironmentSecret":["${{ inputs.app-name }}-${{ inputs.environment }}-environment"],"SplunkIndex":["${{ inputs.splunk-index }}"]}' --timeout-seconds 600 --max-concurrency "10" --max-errors "0" --region ${{ inputs.aws-region  }} --comment "${{ inputs.app-name }}-${{ inputs.environment}}:${{ steps.docker.outputs.tag }}->${{ inputs.on-prem-cluster }}" | tee document-output.json
-          echo "command_id=$(jq -r .Command.CommandId document-output.json)" >> $GITHUB_OUTPUT
+          echo "command_id=$(jq -r .Command.CommandId document-output.json)" >> "$GITHUB_OUTPUT"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.aws-access-key-id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws-secret-access-key }}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 shellcheck 0.7.1
+actionlint 1.6.25


### PR DESCRIPTION
This avoids failures when running on PRs from forks.

We do it in this convoluted way because you can't access secrets directly from `if` blocks: https://github.com/actions/runner/issues/520

The key differences between this and
https://github.com/mbta/workflows/pull/14 are:
- typo: should be `outputs` in the `if` blocks
- more explicity check for the secrets in a Bash script, so we can see the output
- use `yes` instead of `true` as the value to more clearly distinguish the value from a true boolean