### PR TITLE
Chore: Update workflow to use assumed role

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -19,9 +19,7 @@ on:
         required: false
         description: Name of the ECS cluster, defaulting to app-name if not specified
     secrets:
-      aws-access-key-id:
-        required: true
-      aws-secret-access-key:
+      aws-role-arn:
         required: true
       docker-repo:
         required: true
@@ -32,21 +30,22 @@ jobs:
   deploy:
     name: Deploy ${{ github.ref_name }} to ${{ inputs.environment }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     environment: ${{ inputs.environment }}
     concurrency: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@v2
-      - uses: mbta/actions/build-push-ecr@v1
+      - uses: mbta/actions/build-push-ecr@v2
         id: build-push
         with:
-          aws-access-key-id: ${{ secrets.aws-access-key-id }}
-          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+          role-to-assume: ${{ secrets.aws-role-arn }}
           docker-repo: ${{ secrets.docker-repo }}
           dockerfile-path: ${{ inputs.dockerfile-path }}
-      - uses: mbta/actions/deploy-ecs@v1
+      - uses: mbta/actions/deploy-ecs@v2
         with:
-          aws-access-key-id: ${{ secrets.aws-access-key-id }}
-          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+          role-to-assume: ${{ secrets.aws-role-arn }}
           ecs-cluster: ${{ inputs.cluster || inputs.app-name }}
           ecs-service: ${{ inputs.app-name }}-${{ inputs.environment }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}

--- a/.github/workflows/deploy-on-prem.yml
+++ b/.github/workflows/deploy-on-prem.yml
@@ -98,7 +98,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.aws-role-arn }}
-          aws-region: us-east-1
+          aws-region: ${{ inputs.aws-region }}
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Calculate Docker tag

--- a/.github/workflows/deploy-on-prem.yml
+++ b/.github/workflows/deploy-on-prem.yml
@@ -74,9 +74,7 @@ on:
         description: "AWS Region to use (default: us-east-1)"
         default: "us-east-1"
     secrets:
-      aws-access-key-id:
-        required: true
-      aws-secret-access-key:
+      aws-role-arn:
         required: true
       docker-repo:
         required: true
@@ -88,11 +86,19 @@ jobs:
   deploy:
     name: Deploy ${{ github.ref_name }} to ${{ inputs.on-prem-cluster }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     environment: ${{ inputs.environment }}
     concurrency: ${{ inputs.app-name }}-${{ inputs.environment }}
     env:
       AWS_REGION: ${{ inputs.aws-region }}
     steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.aws-role-arn }}
+          aws-region: us-east-1
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Calculate Docker tag
@@ -108,9 +114,6 @@ jobs:
         run: |
           aws ssm send-command --document-name "${{ inputs.document-name }}" --document-version "\$LATEST" --targets '[{"Key":"resource-groups:Name","Values":["${{ inputs.on-prem-cluster }}"]}]' --parameters '{"ECRRepo":["${{ secrets.docker-repo }}"],"DockerTag":["${{ steps.docker.outputs.tag }}"],"TaskCpu":["${{ inputs.task-cpu }}"], "TaskMemory": ["${{ inputs.task-memory }}"],"TaskPort":["${{ inputs.task-port }}"],"PortMode":["${{ inputs.port-mode }}"],"TaskReplicas":["${{ inputs.task-replicas}}"],"UpdateOrder":["${{ inputs.update-order }}"],"PlacementConstraint":["${{ inputs.placement-constraint }}"],"ServiceName":["${{ inputs.app-name }}-${{ inputs.environment }}"],"EnvironmentSecret":["${{ inputs.app-name }}-${{ inputs.environment }}-environment"],"SplunkIndex":["${{ inputs.splunk-index }}"]}' --timeout-seconds 600 --max-concurrency "10" --max-errors "0" --region ${{ inputs.aws-region  }} --comment "${{ inputs.app-name }}-${{ inputs.environment}}:${{ steps.docker.outputs.tag }}->${{ inputs.on-prem-cluster }}" | tee document-output.json
           echo "command_id=$(jq -r .Command.CommandId document-output.json)" >> "$GITHUB_OUTPUT"
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.aws-access-key-id }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws-secret-access-key }}
       - name: Check if deploy started
         if: steps.deploy.outputs.command_id == ''
         run: exit 1
@@ -121,9 +124,6 @@ jobs:
             curl -o .github/await_command_finish.sh https://raw.githubusercontent.com/${{ inputs.await-ref }}/.github/await_command_finish.sh
           fi
           bash .github/await_command_finish.sh ${{ inputs.on-prem-cluster }} ${{ steps.deploy.outputs.command_id }} DockerStackDeploy
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.aws-access-key-id }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws-secret-access-key }}
       - uses: mbta/actions/notify-slack-deploy@v1
         if: inputs.notify-slack && !cancelled()
         with:


### PR DESCRIPTION
Updating the shared workflows to use v2 of the shared `build-push-ecr` and `deploy-ecs` actions. These updated actions assume an IAM role instead of relying on long-lasting AWS keys for an IAM user. 

This PR also updates the on prem deploy workflow to configure AWS credentials and no longer use access keys. I did leave the default region as part of the on prem workflow, as it's used in one of the deploy commands. 

I'll cut a `v2` workflow tag from this branch and begin work to update repos to v2 of this workflow. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205570959197530