### PR TITLE
feat(asana): support link titles in Asana trigger phrase

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -23,7 +23,7 @@ on:
         description: Whether to attach the PR to the Asana ticket. Requires secrets.asana-github-secret.
       trigger-phrase:
         type: string
-        default: "\\*\\*Asana Ticket:\\*\\*(?:(\\s)*\\[.*\\]\\(|(\\s)*)"
+        default: "\\*\\*Asana Ticket:\\*\\*(?:(\\s)*\\[.*\\]\\()?"
         description: Phrase to trigger moving ticket between columns.
     secrets:
       asana-token:

--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -23,7 +23,7 @@ on:
         description: Whether to attach the PR to the Asana ticket. Requires secrets.asana-github-secret.
       trigger-phrase:
         type: string
-        default: "\\*\\*Asana Ticket:\\*\\*(?:(\\s)*\\[.*\\]\\()?"
+        default: "\\*\\*Asana Ticket:\\*\\*"
         description: Phrase to trigger moving ticket between columns.
     secrets:
       asana-token:
@@ -50,7 +50,7 @@ jobs:
     if: inputs.development-section != '' && needs.check-for-secrets.outputs.has-asana-token == 'yes' && (github.event.action == 'opened' || github.event.action == 'reopened') && github.actor != 'dependabot[bot]'
     steps:
       - name: Move ticket to In Development
-        uses: mbta/github-asana-action@v4.3.0
+        uses: mbta/github-asana-action@v4.4.0
         with:
             asana-pat: ${{ secrets.asana-token }}
             trigger-phrase: ${{ inputs.trigger-phrase }}
@@ -61,7 +61,7 @@ jobs:
     if: inputs.merged-section != '' && needs.check-for-secrets.outputs.has-asana-token == 'yes' && github.event.pull_request.merged == true && github.actor != 'dependabot[bot]'
     steps:
       - name: Move ticket on merge
-        uses:  mbta/github-asana-action@v4.3.0
+        uses:  mbta/github-asana-action@v4.4.0
         with:
           asana-pat: ${{ secrets.asana-token }}
           trigger-phrase: ${{ inputs.trigger-phrase }}
@@ -73,7 +73,7 @@ jobs:
     if: inputs.review-section != '' && needs.check-for-secrets.outputs.has-asana-token == 'yes' && github.event.action == 'review_requested' && github.actor != 'dependabot[bot]'
     steps:
       - name: Move ticket on review requested
-        uses:  mbta/github-asana-action@v4.3.0
+        uses:  mbta/github-asana-action@v4.4.0
         with:
           asana-pat: ${{ secrets.asana-token }}
           trigger-phrase: ${{ inputs.trigger-phrase }}

--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -23,7 +23,7 @@ on:
         description: Whether to attach the PR to the Asana ticket. Requires secrets.asana-github-secret.
       trigger-phrase:
         type: string
-        default: "\\*\\*Asana Ticket:\\*\\*"
+        default: "\\*\\*Asana Ticket:\\*\\*(?:(\\s)*\\[.*\\]\\(|(\\s)*)"
         description: Phrase to trigger moving ticket between columns.
     secrets:
       asana-token:


### PR DESCRIPTION
We have PR templates that expect the Asana ticket field to include a markdown link title in the form of `[title](url)`. 

The default setup doesn't support that by default due to the regex in https://github.com/mbta/github-asana-action/blob/a2e76ae34e901ba72df4f7f415c183362e824c68/index.js#L59 and the default value for trigger in https://github.com/mbta/workflows/blob/e7f8691b3f876ea9cd73b50a0a6131d8ad2afb9e/.github/workflows/asana.yml#L22

I tested this update in our of repositories but it'd be nice to re-use it across our repositories.