### PR TITLE
feat(asana): add support for moving an asana task to a development section

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -23,7 +23,7 @@ on:
         description: Whether to attach the PR to the Asana ticket. Requires secrets.asana-github-secret.
       trigger-phrase:
         type: string
-        default: "\\*\\*Asana Ticket:\\*\\*(?:(\\s)*\\[.*\\]\\()?"
+        default: "\\*\\*Asana Ticket:\\*\\*"
         description: Phrase to trigger moving ticket between columns.
     secrets:
       asana-token:

--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
     inputs:
+      development-section:
+        type: string
+        required: false
+        description: The Asana project section for tickets with PRs that are in development. Requires secrets.asana-token.
       merged-section:
         type: string
         required: false
@@ -40,6 +44,17 @@ jobs:
           [ -n "${{ secrets.asana-token }}" ] && echo "has-asana-token=yes" >> "$GITHUB_OUTPUT"
           [ -n "${{ secrets.github-secret }}" ] && echo "has-github-secret=yes" >> "$GITHUB_OUTPUT"
           cat "$GITHUB_OUTPUT"
+  move-to-in-development-asana-ticket-job:
+    runs-on: ubuntu-latest
+    needs: check-for-secrets
+    if: inputs.development-section != '' && needs.check-for-secrets.outputs.has-asana-token == 'yes' && (github.event.action == 'opened' || github.event.action == 'reopened') && github.actor != 'dependabot[bot]'
+    steps:
+      - name: Move ticket to In Development
+        uses: mbta/github-asana-action@v4.3.0
+        with:
+            asana-pat: ${{ secrets.asana-token }}
+            trigger-phrase: ${{ inputs.trigger-phrase }}
+            target-section: ${{ inputs.development-section }}
   move-to-merged-asana-ticket-job:
     runs-on: ubuntu-latest
     needs: check-for-secrets

--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -19,7 +19,7 @@ on:
         description: Whether to attach the PR to the Asana ticket. Requires secrets.asana-github-secret.
       trigger-phrase:
         type: string
-        default: "\\*\\*Asana Ticket:\\*\\*(?:(\\s)*\\[.*\\]\\(|(\\s)*)"
+        default: "\\*\\*Asana Ticket:\\*\\*(?:(\\s)*\\[.*\\]\\()?"
         description: Phrase to trigger moving ticket between columns.
     secrets:
       asana-token:

--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -19,7 +19,7 @@ on:
         description: Whether to attach the PR to the Asana ticket. Requires secrets.asana-github-secret.
       trigger-phrase:
         type: string
-        default: "\\*\\*Asana Ticket:\\*\\*"
+        default: "\\*\\*Asana Ticket:\\*\\*(?:(\\s)*\\[.*\\]\\(|(\\s)*)"
         description: Phrase to trigger moving ticket between columns.
     secrets:
       asana-token:


### PR DESCRIPTION
Includes changes from #19 
I tested this update in our of repositories but it'd be nice to re-use it across our repositories.