### PR TITLE
fix(asana): add continue-on-error for app-attachment

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -104,5 +104,7 @@ jobs:
         id: postAttachment
         with:
           asana-secret: ${{ secrets.github-secret }}
+        continue-on-error: true
+        timeout-minutes: 1
       - name: Log output status
         run: echo "Status is ${{ steps.postAttachment.outputs.status }}"

--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -105,6 +105,5 @@ jobs:
         with:
           asana-secret: ${{ secrets.github-secret }}
         continue-on-error: true
-        timeout-minutes: 1
       - name: Log output status
         run: echo "Status is ${{ steps.postAttachment.outputs.status }}"


### PR DESCRIPTION
I love Asana.

[Failures in gtfs_creator this morning](https://github.com/mbta/gtfs_creator/actions/runs/8158775376/job/22305896026) in https://github.com/mbta/gtfs_creator/pull/2356, this happens to us sporadically with this github action from Asana
Idea to add this configuration from https://github.com/Asana/create-app-attachment-github-action/issues/13