### PR TITLE
feat: add docker-additional-args to deploy-ecs for build-push-ecr

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -10,6 +10,11 @@ on:
         description: Path to the repo's Dockerfile
         required: false
         default: '.'
+      docker-additional-args:
+        type: string
+        description: Additional arguments to pass to call to docker
+        required: false
+        default: ''
       environment:
         type: string
         required: true
@@ -43,6 +48,7 @@ jobs:
           role-to-assume: ${{ secrets.aws-role-arn }}
           docker-repo: ${{ secrets.docker-repo }}
           dockerfile-path: ${{ inputs.dockerfile-path }}
+          docker-additional-args: ${{ inputs.docker-additional-args }}
       - uses: mbta/actions/deploy-ecs@v2
         with:
           role-to-assume: ${{ secrets.aws-role-arn }}


### PR DESCRIPTION
Allows passing docker-additional-args to [build-push-ecr](https://github.com/mbta/actions/blob/27cea46bfb10eaedd00bc2ddff33968919ca39d2/build-push-ecr/action.yml#L18)