### PR TITLE
feat: add allow-zero-desired input to deploy-ecs workflow

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -60,7 +60,7 @@ jobs:
           ecs-cluster: ${{ inputs.cluster || inputs.app-name }}
           ecs-service: ${{ inputs.app-name }}-${{ inputs.environment }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
-          allow-zero-desired: ${{ inputs.allow-zero-desiredf && 'true' || 'false' }}
+          allow-zero-desired: ${{ inputs.allow-zero-desired && 'true' || 'false' }}
       - uses: mbta/actions/notify-slack-deploy@v2
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -23,6 +23,11 @@ on:
         type: string
         required: false
         description: Name of the ECS cluster, defaulting to app-name if not specified
+      allow-zero-desired:
+        type: boolean
+        description: Whether the deploy allows the ECS desiredCount to be 0
+        required: false
+        default: false
     secrets:
       aws-role-arn:
         required: true
@@ -55,6 +60,7 @@ jobs:
           ecs-cluster: ${{ inputs.cluster || inputs.app-name }}
           ecs-service: ${{ inputs.app-name }}-${{ inputs.environment }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
+          allow-zero-desired: ${{ inputs.allow-zero-desiredf && 'true' || 'false' }}
       - uses: mbta/actions/notify-slack-deploy@v2
         if: ${{ !cancelled() }}
         with:


### PR DESCRIPTION
Asana ticket: [🚫 Deploy Cancellations service](https://app.asana.com/1/15492006741476/project/584764604969369/task/1209170494596792)

Bye Bye Bye uses the deploy-ecs workflow, and we'd like to be able to pass in the `allow-zero-desired` option that the deploy-ecs action provides.