### PR TITLE
Add zizmor to checks.yaml; Address all zizmor --pedantic complaints

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,6 @@ updates:
       - "mbta/tid-tech-leads"
     commit-message:
       prefix: "[github-workflows]"
+    cooldown:
+      default-days: 7
       

--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -1,3 +1,6 @@
+name: Manage Asana ticket
+description: Update Asana ticket associated with this pull request
+
 on:
   workflow_call:
     inputs:
@@ -42,6 +45,7 @@ permissions:
 
 jobs:
   check-for-secrets:
+    name: Check that required secrets are set
     runs-on: ubuntu-latest
     outputs:
       has-asana-token: ${{ steps.one.outputs.has-asana-token }}
@@ -57,6 +61,7 @@ jobs:
           # Prefixed with MY_ to avoid trespassing on the GITHUB_* env namespace.
           MY_GITHUB_SECRET: ${{ secrets.github-secret }}
   move-to-in-development-asana-ticket-job:
+    name: Move ticket to In Development column
     runs-on: ubuntu-latest
     needs: check-for-secrets
     if: inputs.development-section != '' && needs.check-for-secrets.outputs.has-asana-token == 'yes' && (github.event.action == 'submitted' && github.event.review.state == 'changes_requested') || (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'converted_to_draft' || github.event.action == 'edited') && (toJson(github.event.pull_request.requested_reviewers) == '[]' && toJson(github.event.pull_request.requested_teams) == '[]' || github.event.pull_request.draft) && github.actor != 'dependabot[bot]'
@@ -68,6 +73,7 @@ jobs:
           trigger-phrase: ${{ inputs.trigger-phrase }}
           target-section: ${{ inputs.development-section }}
   move-to-merged-asana-ticket-job:
+    name: Move ticket to Merged column
     runs-on: ubuntu-latest
     needs: check-for-secrets
     if: inputs.merged-section != '' && needs.check-for-secrets.outputs.has-asana-token == 'yes' && github.event.pull_request.merged == true && github.actor != 'dependabot[bot]'
@@ -80,6 +86,7 @@ jobs:
           target-section: ${{ inputs.merged-section }}
           mark-complete: ${{ inputs.complete-on-merge }}
   move-to-in-review-asana-ticket-job:
+    name: Move ticket to In Review column
     runs-on: ubuntu-latest
     needs: check-for-secrets
     if: inputs.review-section != '' && needs.check-for-secrets.outputs.has-asana-token == 'yes' && (github.event.action == 'review_requested' || github.event.action == 'ready_for_review' && (toJson(github.event.pull_request.requested_reviewers) != '[]' || toJson(github.event.pull_request.requested_teams) != '[]')) && !github.event.pull_request.draft && github.actor != 'dependabot[bot]'
@@ -91,6 +98,7 @@ jobs:
           trigger-phrase: ${{ inputs.trigger-phrase }}
           target-section: ${{ inputs.review-section }}
   move-to-approved-asana-ticket-job:
+    name: Move ticket to Approved column
     runs-on: ubuntu-latest
     needs: check-for-secrets
     if: inputs.approved-section != '' && needs.check-for-secrets.outputs.has-asana-token == 'yes' && github.event.action == 'submitted' && github.event.review.state == 'approved' && !github.event.pull_request.draft && github.actor != 'dependabot[bot]'
@@ -102,9 +110,9 @@ jobs:
           trigger-phrase: ${{ inputs.trigger-phrase }}
           target-section: ${{ inputs.approved-section }}
   create-asana-attachment-job:
+    name: Create pull request attachments on Asana tasks
     runs-on: ubuntu-latest
     needs: check-for-secrets
-    name: Create pull request attachments on Asana tasks
     if: inputs.attach-pr && needs.check-for-secrets.outputs.has-github-secret == 'yes' && github.actor != 'dependabot[bot]'
     steps:
       - name: Create pull request attachments

--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -45,9 +45,13 @@ jobs:
     steps:
       - id: one
         run: |
-          [ -n "${{ secrets.asana-token }}" ] && echo "has-asana-token=yes" >> "$GITHUB_OUTPUT"
-          [ -n "${{ secrets.github-secret }}" ] && echo "has-github-secret=yes" >> "$GITHUB_OUTPUT"
+          [ -n "${ASANA_TOKEN}" ] && echo "has-asana-token=yes" >> "$GITHUB_OUTPUT"
+          [ -n "${MY_GITHUB_SECRET}" ] && echo "has-github-secret=yes" >> "$GITHUB_OUTPUT"
           cat "$GITHUB_OUTPUT"
+        env:
+          ASANA_TOKEN: ${{ secrets.asana-token }}
+          # Prefixed with MY_ to avoid trespassing on the GITHUB_* env namespace.
+          MY_GITHUB_SECRET: ${{ secrets.github-secret }}
   move-to-in-development-asana-ticket-job:
     runs-on: ubuntu-latest
     needs: check-for-secrets

--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -106,4 +106,6 @@ jobs:
           asana-secret: ${{ secrets.github-secret }}
         continue-on-error: true
       - name: Log output status
-        run: echo "Status is ${{ steps.postAttachment.outputs.status }}"
+        run: echo "Status is ${POST_ATTACHMENT_STATUS}"
+        env:
+          POST_ATTACHMENT_STATUS: ${{ steps.postAttachment.outputs.status }}

--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -36,6 +36,10 @@ on:
       github-secret:
         required: false
         description: GitHub secret that Asana uses to fetch PR information.
+
+permissions:
+  pull-requests: read # Needed to read Asana ticket info from PR description
+
 jobs:
   check-for-secrets:
     runs-on: ubuntu-latest

--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -67,7 +67,7 @@ jobs:
     if: inputs.development-section != '' && needs.check-for-secrets.outputs.has-asana-token == 'yes' && (github.event.action == 'submitted' && github.event.review.state == 'changes_requested') || (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'converted_to_draft' || github.event.action == 'edited') && (toJson(github.event.pull_request.requested_reviewers) == '[]' && toJson(github.event.pull_request.requested_teams) == '[]' || github.event.pull_request.draft) && github.actor != 'dependabot[bot]'
     steps:
       - name: Move ticket to In Development
-        uses: mbta/github-asana-action@v4.4.3
+        uses: mbta/github-asana-action@a55ffe54dfdcc5190ab2204f146941890499da3f # v4.4.3
         with:
           asana-pat: ${{ secrets.asana-token }}
           trigger-phrase: ${{ inputs.trigger-phrase }}
@@ -79,7 +79,7 @@ jobs:
     if: inputs.merged-section != '' && needs.check-for-secrets.outputs.has-asana-token == 'yes' && github.event.pull_request.merged == true && github.actor != 'dependabot[bot]'
     steps:
       - name: Move ticket on merge
-        uses: mbta/github-asana-action@v4.4.3
+        uses: mbta/github-asana-action@a55ffe54dfdcc5190ab2204f146941890499da3f # v4.4.3
         with:
           asana-pat: ${{ secrets.asana-token }}
           trigger-phrase: ${{ inputs.trigger-phrase }}
@@ -92,7 +92,7 @@ jobs:
     if: inputs.review-section != '' && needs.check-for-secrets.outputs.has-asana-token == 'yes' && (github.event.action == 'review_requested' || github.event.action == 'ready_for_review' && (toJson(github.event.pull_request.requested_reviewers) != '[]' || toJson(github.event.pull_request.requested_teams) != '[]')) && !github.event.pull_request.draft && github.actor != 'dependabot[bot]'
     steps:
       - name: Move ticket on review requested
-        uses: mbta/github-asana-action@v4.4.3
+        uses: mbta/github-asana-action@a55ffe54dfdcc5190ab2204f146941890499da3f # v4.4.3
         with:
           asana-pat: ${{ secrets.asana-token }}
           trigger-phrase: ${{ inputs.trigger-phrase }}
@@ -104,7 +104,7 @@ jobs:
     if: inputs.approved-section != '' && needs.check-for-secrets.outputs.has-asana-token == 'yes' && github.event.action == 'submitted' && github.event.review.state == 'approved' && !github.event.pull_request.draft && github.actor != 'dependabot[bot]'
     steps:
       - name: Move ticket on approval
-        uses: mbta/github-asana-action@v4.4.3
+        uses: mbta/github-asana-action@a55ffe54dfdcc5190ab2204f146941890499da3f # v4.4.3
         with:
           asana-pat: ${{ secrets.asana-token }}
           trigger-phrase: ${{ inputs.trigger-phrase }}
@@ -116,7 +116,7 @@ jobs:
     if: inputs.attach-pr && needs.check-for-secrets.outputs.has-github-secret == 'yes' && github.actor != 'dependabot[bot]'
     steps:
       - name: Create pull request attachments
-        uses: Asana/create-app-attachment-github-action@v1.3
+        uses: Asana/create-app-attachment-github-action@affc72d57bac733d864d4189ed69a9cbd61a9e4f # v1.3
         id: postAttachment
         with:
           asana-secret: ${{ secrets.github-secret }}

--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -56,16 +56,16 @@ jobs:
       - name: Move ticket to In Development
         uses: mbta/github-asana-action@v4.4.3
         with:
-            asana-pat: ${{ secrets.asana-token }}
-            trigger-phrase: ${{ inputs.trigger-phrase }}
-            target-section: ${{ inputs.development-section }}
+          asana-pat: ${{ secrets.asana-token }}
+          trigger-phrase: ${{ inputs.trigger-phrase }}
+          target-section: ${{ inputs.development-section }}
   move-to-merged-asana-ticket-job:
     runs-on: ubuntu-latest
     needs: check-for-secrets
     if: inputs.merged-section != '' && needs.check-for-secrets.outputs.has-asana-token == 'yes' && github.event.pull_request.merged == true && github.actor != 'dependabot[bot]'
     steps:
       - name: Move ticket on merge
-        uses:  mbta/github-asana-action@v4.4.3
+        uses: mbta/github-asana-action@v4.4.3
         with:
           asana-pat: ${{ secrets.asana-token }}
           trigger-phrase: ${{ inputs.trigger-phrase }}
@@ -77,7 +77,7 @@ jobs:
     if: inputs.review-section != '' && needs.check-for-secrets.outputs.has-asana-token == 'yes' && (github.event.action == 'review_requested' || github.event.action == 'ready_for_review' && (toJson(github.event.pull_request.requested_reviewers) != '[]' || toJson(github.event.pull_request.requested_teams) != '[]')) && !github.event.pull_request.draft && github.actor != 'dependabot[bot]'
     steps:
       - name: Move ticket on review requested
-        uses:  mbta/github-asana-action@v4.4.3
+        uses: mbta/github-asana-action@v4.4.3
         with:
           asana-pat: ${{ secrets.asana-token }}
           trigger-phrase: ${{ inputs.trigger-phrase }}
@@ -88,7 +88,7 @@ jobs:
     if: inputs.approved-section != '' && needs.check-for-secrets.outputs.has-asana-token == 'yes' && github.event.action == 'submitted' && github.event.review.state == 'approved' && !github.event.pull_request.draft && github.actor != 'dependabot[bot]'
     steps:
       - name: Move ticket on approval
-        uses:  mbta/github-asana-action@v4.4.3
+        uses: mbta/github-asana-action@v4.4.3
         with:
           asana-pat: ${{ secrets.asana-token }}
           trigger-phrase: ${{ inputs.trigger-phrase }}

--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -1,5 +1,4 @@
 name: Manage Asana ticket
-description: Update Asana ticket associated with this pull request
 
 on:
   workflow_call:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,4 +1,3 @@
----
 name: Checks
 
 on: [push]

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -3,13 +3,15 @@ name: Checks
 
 on: [push]
 
-jobs:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
     steps:
-
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
@@ -29,7 +31,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-
       - uses: actions/checkout@v6
         with:
           persist-credentials: false

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,18 +11,18 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       # cache the ASDF directory, using the values from .tool-versions
       - name: ASDF cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-v2-${{ hashFiles('.tool-versions') }}
         id: asdf-cache
       # only run `asdf install` if we didn't hit the cache
-      - uses: asdf-vm/actions/install@v4
+      - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
         if: steps.asdf-cache.outputs.cache-hit != 'true'
 
   lint_scripts:
@@ -30,17 +30,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: ASDF cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-v2-${{ hashFiles('.tool-versions') }}
         id: asdf-cache
       - name: Setup ASDF environment
-        uses: mbta/actions/reshim-asdf@v2
+        uses: mbta/actions/reshim-asdf@d37877022d4ae12e96663d2e0a970a5214a2e232 # v2.20
       - name: Shellcheck
         run: if ls .github/*.sh >/dev/null 2>&1; then shellcheck -a -S style .github/*.sh; fi
       - name: Check workflow files

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -49,8 +49,6 @@ jobs:
   zizmor:
     name: Run zizmor 🌈
     runs-on: ubuntu-latest
-    permissions:
-      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -61,3 +59,4 @@ jobs:
         with:
           persona: pedantic
           inputs: .github/workflows # Prevents zizmor from auditing dependabot.yml
+          advanced-security: false

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -58,5 +58,4 @@ jobs:
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:
           persona: pedantic
-          inputs: .github/workflows # Prevents zizmor from auditing dependabot.yml
           advanced-security: false

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -50,10 +50,15 @@ jobs:
   zizmor:
     name: Run zizmor 🌈
     runs-on: ubuntu-latest
-    needs: setup
     permissions:
       security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
-      actions: read # Only needed for private repos. Needed for upload-sarif to read workflow run info.
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Run zizmor 🌈
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          persona: pedantic
+          inputs: .github/workflows # Prevents zizmor from auditing dependabot.yml

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -2,6 +2,8 @@ name: Checks
 
 on: [push]
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -2,8 +2,7 @@ name: Checks
 
 on: [push]
 
-permissions:
-  contents: read # Only needed for private repos. Needed to clone the repo.
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -2,7 +2,8 @@ name: Checks
 
 on: [push]
 
-permissions: {}
+permissions:
+  contents: read # Only needed for private repos. Needed to clone the repo.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -26,7 +27,6 @@ jobs:
       # only run `asdf install` if we didn't hit the cache
       - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
         if: steps.asdf-cache.outputs.cache-hit != 'true'
-
   lint_scripts:
     name: Lint Scripts
     runs-on: ubuntu-latest
@@ -47,3 +47,13 @@ jobs:
         run: if ls .github/*.sh >/dev/null 2>&1; then shellcheck -a -S style .github/*.sh; fi
       - name: Check workflow files
         run: actionlint -color
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    needs: setup
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      actions: read # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+    steps:
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,6 +11,8 @@ jobs:
     steps:
 
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       # cache the ASDF directory, using the values from .tool-versions
       - name: ASDF cache
         uses: actions/cache@v5
@@ -29,6 +31,8 @@ jobs:
     steps:
 
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: ASDF cache
         uses: actions/cache@v5
         with:

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -1,3 +1,6 @@
+name: Deploy to ECS
+description: Deploy change to ECS environment
+
 on:
   workflow_call:
     inputs:
@@ -9,17 +12,17 @@ on:
         type: string
         description: Path to the repo's Dockerfile
         required: false
-        default: '.'
+        default: "."
       docker-additional-args:
         type: string
         description: Additional arguments to pass to call to docker
         required: false
-        default: ''
+        default: ""
       docker-additional-tags:
         type: string
         description: Additional tags for the image, separated by spaces
         required: false
-        default: ''
+        default: ""
       environment:
         type: string
         required: true

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -52,6 +52,8 @@ jobs:
     concurrency: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: mbta/actions/build-push-ecr@v2
         id: build-push
         with:

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -1,5 +1,4 @@
 name: Deploy to ECS
-description: Deploy change to ECS environment
 
 on:
   workflow_call:

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -44,13 +44,15 @@ on:
       slack-webhook:
         required: true
 
+permissions: {}
+
 jobs:
   deploy:
     name: Deploy ${{ github.ref_name }} to ${{ inputs.environment }}
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      contents: read
+      id-token: write # Needed to access ECR and ECS
+      contents: read # Needed to access commit details and other repository info
     environment: ${{ inputs.environment }}
     concurrency: ${{ inputs.environment }}
     steps:

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -54,10 +54,10 @@ jobs:
     environment: ${{ inputs.environment }}
     concurrency: ${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: mbta/actions/build-push-ecr@v2
+      - uses: mbta/actions/build-push-ecr@d37877022d4ae12e96663d2e0a970a5214a2e232 # v2.20
         id: build-push
         with:
           role-to-assume: ${{ secrets.aws-role-arn }}
@@ -65,14 +65,14 @@ jobs:
           dockerfile-path: ${{ inputs.dockerfile-path }}
           docker-additional-args: ${{ inputs.docker-additional-args }}
           docker-additional-tags: ${{ inputs.docker-additional-tags }}
-      - uses: mbta/actions/deploy-ecs@v2
+      - uses: mbta/actions/deploy-ecs@d37877022d4ae12e96663d2e0a970a5214a2e232 # v2.20
         with:
           role-to-assume: ${{ secrets.aws-role-arn }}
           ecs-cluster: ${{ inputs.cluster || inputs.app-name }}
           ecs-service: ${{ inputs.app-name }}-${{ inputs.environment }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
           allow-zero-desired: ${{ inputs.allow-zero-desired && 'true' || 'false' }}
-      - uses: mbta/actions/notify-slack-deploy@v2
+      - uses: mbta/actions/notify-slack-deploy@d37877022d4ae12e96663d2e0a970a5214a2e232 # v2.20
         if: ${{ !cancelled() }}
         with:
           webhook-url: ${{ secrets.slack-webhook }}


### PR DESCRIPTION
Part of the effort to add zizmor to all our projects for improved GitHub Actions security.

Specifying permissions on the reusable workflows defined in this project saves us the effort of specifying those permissions repeatedly in every place where they are used.

Testing:
I'm working on similar changes in rtr right now, so I'll check that these changes are safe by temporarily pointing rtr's usages of the `asana` and `deploy-ecs` workflows at the head of this branch.